### PR TITLE
Fix clicking noises

### DIFF
--- a/src/include/TankVerb.h
+++ b/src/include/TankVerb.h
@@ -34,27 +34,17 @@ float lerp(float x, float y0, float y1)
 // unless preventOverrun is set to true, current array size must be at least 1 bigger than currentSize
 // otherwise, the last iteration of the resize loop will try to access an element outside the input array bounds to interpolate
 // preventOverrun prevents this by iterating until currentSize-1 and copying the last element of current into the last element of out
-inline bool resizeNearestNeighbor(const float *current, size_t currentSize, float *out, size_t newSize, bool preventOverrun = false)
+inline bool resizeNearestNeighbor(const float *current, size_t currentSize, float *out, size_t newSize)
 {
 	const float scaleFactor = static_cast<float>(currentSize) / static_cast<float>(newSize);
 
-	size_t targetSize = newSize;
-	if (preventOverrun)
-	{
-		--targetSize;
-	}
-
-	for (size_t outIdx = 0; outIdx < targetSize; ++outIdx)
+	for (size_t outIdx = 0; outIdx < newSize; ++outIdx)
 	{
 		const float currentFractionalIdx = outIdx * scaleFactor;
 		const int currentIdx = static_cast<size_t>(currentFractionalIdx);
 		out[outIdx] = lerp(currentFractionalIdx - currentIdx, current[currentIdx], current[currentIdx + 1]);
 	}
 
-	if (preventOverrun)
-	{
-		out[newSize - 1] = current[currentSize - 1];
-	}
 	return true;
 }
 
@@ -97,7 +87,7 @@ public:
 		resizeOutputBuffer[0] = mPrevOut;
 		resizeNearestNeighbor(resizeOutputBuffer, newSize, output, blockSize);
 		mPrevIn = input[AUDIO_BLOCK_SIZE - 1];
-		mPrevOut = resizeOutputBuffer[newSize ];
+		mPrevOut = resizeOutputBuffer[newSize];
 	}
 
 	void reset()

--- a/src/include/TankVerb.h
+++ b/src/include/TankVerb.h
@@ -12,12 +12,12 @@ static constexpr size_t NUM_DELAYS = 4;
 static constexpr size_t MAX_DELAY_LENGTH = 16384;
 static constexpr size_t MAX_BUFFER_LENGTH = 6200;
 float resizeOutputBuffer[MAX_BUFFER_LENGTH];
+float resizeInputBuffer[MAX_BUFFER_LENGTH];
 
 // the variables are not used in code, but they let user preview the delay properties in IDE or compile time
 static constexpr float minDelayLengthSeconds = (MAX_DELAY_LENGTH / (float)SAMPLE_RATE) / (MAX_BUFFER_LENGTH / AUDIO_BLOCK_SIZE);
 static constexpr float maxDelayLengthSeconds = (MAX_DELAY_LENGTH / (float)SAMPLE_RATE);
 static constexpr float expansionFactor = maxDelayLengthSeconds / minDelayLengthSeconds;
-
 
 // Very similar to tanh in <-1, 1> range and decaying to 0 outside of that range
 inline float softClip(float sample)
@@ -25,26 +25,39 @@ inline float softClip(float sample)
 	return sample - 0.333333f * sample * sample * sample;
 }
 
-float lerp(float x, float x0, float x1, float y0, float y1)
+float lerp(float x, float y0, float y1)
 {
-	return y0 + (x - x0) * ((y1 - y0) / (x1 - x0));
+	return y0 + x * ((y1 - y0));
 }
 
-inline bool resizeNearestNeighbor(const float* current, size_t currentSize, float* out, size_t newSize)
+// unless preventOverrun is set to true, current array size must be at least 1 bigger than currentSize
+// otherwise, the last iteration of the resize loop will try to access an element outside the input array bounds to interpolate
+// preventOverrun prevents this by iterating until currentSize-1 and copying the last element of current into the last element of out
+inline bool resizeNearestNeighbor(const float *current, size_t currentSize, float *out, size_t newSize, bool preventOverrun = false)
 {
 	const float scaleFactor = static_cast<float>(currentSize) / static_cast<float>(newSize);
-	for (size_t outIdx = 0; outIdx < newSize - 1; ++outIdx)
+
+	size_t targetSize = newSize;
+	if (preventOverrun)
+	{
+		--targetSize;
+	}
+
+	for (size_t outIdx = 0; outIdx < targetSize; ++outIdx)
 	{
 		const float currentFractionalIdx = outIdx * scaleFactor;
 		const int currentIdx = static_cast<size_t>(currentFractionalIdx);
-		out[outIdx] = lerp(currentFractionalIdx, currentIdx, currentIdx + 1, current[currentIdx], current[currentIdx + 1]); // current[currentIdx]; 
+		out[outIdx] = lerp(currentFractionalIdx - currentIdx, current[currentIdx], current[currentIdx + 1]);
 	}
 
-	out[newSize - 1] = current[currentSize - 1];
+	if (preventOverrun)
+	{
+		out[newSize - 1] = current[currentSize - 1];
+	}
 	return true;
 }
 
-class BucketBrigadeDelay 
+class BucketBrigadeDelay
 {
 public:
 	BucketBrigadeDelay()
@@ -54,49 +67,54 @@ public:
 		setLength(MAX_DELAY_LENGTH);
 	}
 
-	void update(const float* input, float* output, size_t blockSize)
+	void update(const float *input, float *output, size_t blockSize)
 	{
 		// rather than changing the actual delay line length, we just resample
 		// the input and output, simulating change of clock speed in BBD delay
-		size_t newSize = (MAX_DELAY_LENGTH / mNewLength) * blockSize;		
-		if(newSize >= MAX_BUFFER_LENGTH) {
-			newSize = MAX_BUFFER_LENGTH -1;
+		size_t newSize = (MAX_DELAY_LENGTH / mNewLength) * blockSize;
+		if (newSize >= MAX_BUFFER_LENGTH)
+		{
+			newSize = MAX_BUFFER_LENGTH - 1;
 		}
-		if(newSize < blockSize) {
+		if (newSize < blockSize)
+		{
 			newSize = blockSize;
 		}
 
-		const float inputOutputScaleFactor = static_cast<float>(blockSize) / static_cast<float>(newSize);
-		for(int i=0; i<newSize - 1; ++i) {
-			const float currentFractionalIdx = i * inputOutputScaleFactor;
-			const int currentIdx = static_cast<size_t>(currentFractionalIdx);
-			const float inputInterpolated = lerp(currentFractionalIdx, currentIdx, currentIdx + 1, input[currentIdx], input[currentIdx + 1]);
-			updateDelay(inputInterpolated, resizeOutputBuffer, i);
+		memcpy(mExtendedInput + extraSize, input, AUDIO_BLOCK_SIZE * sizeof(float));
+		mExtendedInput[0] = mPrevIn;
+		resizeNearestNeighbor(mExtendedInput, blockSize, resizeInputBuffer, newSize);
+		for (int i = 0; i < newSize; ++i)
+		{
+			updateDelay(resizeInputBuffer[i], resizeInputBuffer, i);
 		}
-		// we can't go to the last index, because lerp would read outside of input array bounds, so the last element gets simply copied
-		updateDelay(input[blockSize - 1], resizeOutputBuffer, newSize - 1);
-
-		resizeNearestNeighbor(resizeOutputBuffer, newSize, output, blockSize);
+		resizeNearestNeighbor(resizeInputBuffer, newSize, output, blockSize, true);
+		mPrevIn = input[AUDIO_BLOCK_SIZE - 1];
 	}
 
-	void reset() {
-		if(!mIsReset) {
+	void reset()
+	{
+		if (!mIsReset)
+		{
 			mDelay.reset();
 			mIsReset = true;
 		}
 	}
 
-    bool isReset() {
-        return mIsReset;
-    }
+	bool isReset()
+	{
+		return mIsReset;
+	}
 
 	void setCutoff(float cutoffFrequency)
 	{
 		mFilter.SetFreq(cutoffFrequency);
 	}
 
-	bool setGain(float gain) {
-		if (gain > 1.1f) {
+	bool setGain(float gain)
+	{
+		if (gain > 1.1f)
+		{
 			return false;
 		}
 
@@ -111,15 +129,15 @@ public:
 	}
 
 private:
+	void updateDelay(float input, float *output, size_t outputIndex)
+	{
+		float out = softClip(mDelay.read());
+		out = mFilter.Process(out);
+		mDelay.write(input + out * mGain);
+		float average = (input + out) * .5f;
 
-	void updateDelay(float input, float* output, size_t outputIndex) {
-            float out = softClip(mDelay.read());
-			out = mFilter.Process(out);
-			mDelay.write(input + out * mGain);
-			float average = (input + out) * .5f;
-
-			output[outputIndex] = average;
-		};
+		output[outputIndex] = average;
+	};
 
 	bool mIsReset = true;
 	daisysp::Tone mFilter;
@@ -128,16 +146,21 @@ private:
 	float mOldLength;
 	float mNewLength;
 	float mOffset;
+
+	// introduces one or more samplse of extra delay
+	// to avoid problems with interpolation overruning the input samples array
+	float mPrevIn = 0;
+	static constexpr size_t extraSize = 1;
+	float mExtendedInput[AUDIO_BLOCK_SIZE + extraSize];
 };
 
 class TankVerb
 {
 public:
-	TankVerb() :
-		mCurrentNumDelays(NUM_DELAYS),
-		mMaxDelayNumber(NUM_DELAYS),
-		mMaxRoomSize(MAX_DELAY_LENGTH),
-		mCurrentRoomSize(MAX_DELAY_LENGTH)
+	TankVerb() : mCurrentNumDelays(NUM_DELAYS),
+				 mMaxDelayNumber(NUM_DELAYS),
+				 mMaxRoomSize(MAX_DELAY_LENGTH),
+				 mCurrentRoomSize(MAX_DELAY_LENGTH)
 	{
 		setLength(MAX_DELAY_LENGTH);
 	}
@@ -154,7 +177,7 @@ public:
 
 	void setCutoff(float cutoffFrequency)
 	{
-		for(auto& delay : mDelays)
+		for (auto &delay : mDelays)
 		{
 			delay.setCutoff(cutoffFrequency);
 		}
@@ -168,25 +191,27 @@ public:
 		}
 
 		//// disable one delay line at very short delay length to save CPU
-		//if(length < 0.075f * MAX_DELAY_LENGTH) {
+		// if(length < 0.075f * MAX_DELAY_LENGTH) {
 		//	mDelays.back().reset();
 		//	setNumDelays(mMaxDelayNumber - 1);
-		//}
-		//else {
+		// }
+		// else {
 		//	setNumDelays(mMaxDelayNumber);
-		//}
-		
+		// }
+
 		mCurrentRoomSize = length;
 
 		const unsigned scaleFactor = mMaxDelayNumber > 1u ? (length - mMinLength) / (mMaxDelayNumber - 1u) : 1u;
-		for(int i=0; i<mMaxDelayNumber; ++i) {
+		for (int i = 0; i < mMaxDelayNumber; ++i)
+		{
 			mDelays[i].setLength(mCurrentRoomSize - i * scaleFactor);
 		}
 	}
 
 	void setGain(float gain)
 	{
-		for (unsigned int i = 0u; i < mMaxDelayNumber; ++i) {
+		for (unsigned int i = 0u; i < mMaxDelayNumber; ++i)
+		{
 			mDelays[i].setGain(gain);
 		}
 	}
@@ -206,7 +231,7 @@ public:
 	}
 
 	float tmp[AUDIO_BLOCK_SIZE];
-	void update(const float* const input, float* output, unsigned count)
+	void update(const float *const input, float *output, unsigned count)
 	{
 		if (input == nullptr || output == nullptr || count != AUDIO_BLOCK_SIZE)
 		{
@@ -225,7 +250,6 @@ public:
 			}
 		}
 	}
-
 
 private:
 	unsigned int mCurrentNumDelays;


### PR DESCRIPTION
Introduces an extra sample of delay to prevent overrunning the input or output arrays for resampling. 
The original approach was to simply copy the last input element to the output (during resizeNearestNeighbor) to prevent the overrun, but this method was not sufficiently good and was causing audible clicking noises.